### PR TITLE
Feat: 관리자기능 추가 및 커스텀 예외 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'io.github.cdimascio:java-dotenv:5.2.2'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/demo/admin/controller/AdminReportController.java
+++ b/src/main/java/com/example/demo/admin/controller/AdminReportController.java
@@ -1,0 +1,58 @@
+package com.example.demo.admin.controller;
+
+import java.util.Map;
+import java.util.UUID;
+
+import com.example.demo.admin.dto.AdminReportRequestDto;
+import com.example.demo.admin.dto.AdminReportResponseDto;
+import com.example.demo.admin.dto.AdminReportUpdateRequestDto;
+import com.example.demo.admin.service.AdminReportService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/reports")
+public class AdminReportController {
+
+	private final AdminReportService adminReportService;
+
+	@PostMapping
+	public ResponseEntity<AdminReportResponseDto> createReport(
+		@RequestBody AdminReportRequestDto dto,
+		@AuthenticationPrincipal String userId
+	) {
+		UUID reporterId = UUID.fromString(userId);
+		AdminReportResponseDto response = adminReportService.createReport(dto, reporterId);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/{reportId}")
+	public ResponseEntity<AdminReportResponseDto> getReportById(@PathVariable UUID reportId) {
+		AdminReportResponseDto response = adminReportService.getReportById(reportId);
+		return ResponseEntity.ok(response);
+	}
+
+	@PutMapping("/{reportId}/status")
+	public ResponseEntity<AdminReportResponseDto> updateReportStatus(
+		@PathVariable UUID reportId,
+		@RequestBody AdminReportUpdateRequestDto dto,
+		@AuthenticationPrincipal String userId // 관리자 ID
+	) {
+		UUID adminId = UUID.fromString(userId);
+		AdminReportResponseDto response = adminReportService.updateReportStatus(reportId, dto.getStatus(), adminId);
+		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping("/{reportId}")
+	public ResponseEntity<Map<String, String>> deleteReport(
+		@PathVariable UUID reportId,
+		@AuthenticationPrincipal String userId // 관리자 ID
+	) {
+		adminReportService.deleteReport(reportId, UUID.fromString(userId));
+		return ResponseEntity.ok().body(Map.of("message", "신고 내역이 삭제되었습니다."));
+	}
+}

--- a/src/main/java/com/example/demo/admin/controller/AdminStoreController.java
+++ b/src/main/java/com/example/demo/admin/controller/AdminStoreController.java
@@ -1,4 +1,4 @@
-package com.example.demo.store.controller;
+package com.example.demo.admin.controller;
 
 import java.util.UUID;
 
@@ -16,7 +16,7 @@ import com.example.demo.store.service.StoreService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/admin/stores")
+@RequestMapping("/api/admin/stores")
 @RequiredArgsConstructor
 public class AdminStoreController {
 

--- a/src/main/java/com/example/demo/admin/controller/AdminUserSanctionController.java
+++ b/src/main/java/com/example/demo/admin/controller/AdminUserSanctionController.java
@@ -1,0 +1,49 @@
+package com.example.demo.admin.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.demo.admin.dto.AdminUserSanctionRequestDto;
+import com.example.demo.admin.dto.AdminUserSanctionResponseDto;
+import com.example.demo.admin.service.AdminUserSanctionService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/sanctions")
+public class AdminUserSanctionController {
+
+	private final AdminUserSanctionService sanctionService;
+
+	@PostMapping
+	public ResponseEntity<AdminUserSanctionResponseDto> createSanction(
+		@RequestBody AdminUserSanctionRequestDto dto,
+		@AuthenticationPrincipal String adminId
+	) {
+		return ResponseEntity.ok(
+			sanctionService.createSanction(dto, UUID.fromString(adminId))
+		);
+	}
+
+	@GetMapping
+	public ResponseEntity<List<AdminUserSanctionResponseDto>> getAllSanctions() {
+		return ResponseEntity.ok(sanctionService.getAllSanctions());
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<?> deleteSanction(@PathVariable UUID id, @AuthenticationPrincipal String adminId) {
+		sanctionService.deleteSanction(id, UUID.fromString(adminId));
+		return ResponseEntity.ok("제재 삭제 완료");
+	}
+}

--- a/src/main/java/com/example/demo/admin/controller/ReportController.java
+++ b/src/main/java/com/example/demo/admin/controller/ReportController.java
@@ -1,0 +1,29 @@
+package com.example.demo.admin.controller;
+
+import com.example.demo.admin.dto.AdminReportRequestDto;
+import com.example.demo.admin.dto.AdminReportResponseDto;
+import com.example.demo.admin.service.AdminReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reports")
+public class ReportController {
+
+	private final AdminReportService adminReportService;
+
+	@PostMapping
+	public ResponseEntity<AdminReportResponseDto> createReport(
+		@RequestBody AdminReportRequestDto dto,
+		@AuthenticationPrincipal String userId // 신고자
+	) {
+		UUID reporterId = UUID.fromString(userId);
+		AdminReportResponseDto response = adminReportService.createReport(dto, reporterId);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/com/example/demo/admin/dto/AdminReportRequestDto.java
+++ b/src/main/java/com/example/demo/admin/dto/AdminReportRequestDto.java
@@ -1,11 +1,14 @@
 package com.example.demo.admin.dto;
 
 import java.util.UUID;
+
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 public class AdminReportRequestDto {
 	private UUID reportedId;     // 피신고 대상 ID
 	private String reportType;   // USER, STORE, REVIEW

--- a/src/main/java/com/example/demo/admin/dto/AdminReportRequestDto.java
+++ b/src/main/java/com/example/demo/admin/dto/AdminReportRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.demo.admin.dto;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminReportRequestDto {
+	private UUID reportedId;     // 피신고 대상 ID
+	private String reportType;   // USER, STORE, REVIEW
+	private String content;      // 신고 내용
+}

--- a/src/main/java/com/example/demo/admin/dto/AdminReportResponseDto.java
+++ b/src/main/java/com/example/demo/admin/dto/AdminReportResponseDto.java
@@ -1,7 +1,6 @@
 package com.example.demo.admin.dto;
 
 import com.example.demo.admin.entity.AdminReport;
-import com.example.demo.user.entity.UserEntity;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/example/demo/admin/dto/AdminReportResponseDto.java
+++ b/src/main/java/com/example/demo/admin/dto/AdminReportResponseDto.java
@@ -1,0 +1,51 @@
+package com.example.demo.admin.dto;
+
+import com.example.demo.admin.entity.AdminReport;
+import com.example.demo.user.entity.UserEntity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class AdminReportResponseDto {
+	private UUID reportId;
+	private String reportType;
+	private String content;
+	private String status;
+	private LocalDateTime createdAt;
+
+	private UserInfoDto reporter;
+	private UserInfoDto reported;
+
+	@Getter
+	@Builder
+	public static class UserInfoDto {
+		private UUID userId;
+		private String nickname;
+		private String email;
+	}
+
+	public static AdminReportResponseDto fromEntity(AdminReport entity) {
+		return AdminReportResponseDto.builder()
+			.reportId(entity.getReportId())
+			.reportType(entity.getReportType())
+			.content(entity.getContent())
+			.status(entity.getStatus().getDescription())
+			.createdAt(entity.getCreatedAt())
+			.reporter(UserInfoDto.builder()
+				.userId(entity.getReporter().getUserId())
+				.nickname(entity.getReporter().getNickname())
+				.email(entity.getReporter().getEmail())
+				.build())
+			.reported(UserInfoDto.builder()
+				.userId(entity.getReported().getUserId())
+				.nickname(entity.getReported().getNickname())
+				.email(entity.getReported().getEmail())
+				.build())
+			.build();
+	}
+}

--- a/src/main/java/com/example/demo/admin/dto/AdminReportUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/admin/dto/AdminReportUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.demo.admin.dto;
+
+import com.example.demo.admin.entity.ReportStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminReportUpdateRequestDto {
+	private ReportStatus status;
+}

--- a/src/main/java/com/example/demo/admin/dto/AdminUserSanctionRequestDto.java
+++ b/src/main/java/com/example/demo/admin/dto/AdminUserSanctionRequestDto.java
@@ -1,0 +1,20 @@
+package com.example.demo.admin.dto;
+
+import com.example.demo.admin.entity.SanctionStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+@Getter
+public class AdminUserSanctionRequestDto {
+	private UUID userId;
+	private String reason;
+	private SanctionStatus sanctionStatus;
+	private LocalDateTime startDate;
+	private LocalDateTime endDate;
+	private String note;
+}

--- a/src/main/java/com/example/demo/admin/dto/AdminUserSanctionResponseDto.java
+++ b/src/main/java/com/example/demo/admin/dto/AdminUserSanctionResponseDto.java
@@ -1,0 +1,45 @@
+package com.example.demo.admin.dto;
+
+import com.example.demo.admin.entity.AdminUserSanction;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class AdminUserSanctionResponseDto {
+
+	private UUID sanctionId;
+	private UUID userId;
+	private String reason;
+	private String sanctionStatus;
+	private String note;
+	private LocalDateTime startDate;
+	private LocalDateTime endDate;
+	private LocalDateTime createdAt;
+	private UUID createdBy;
+	private LocalDateTime updatedAt;
+	private UUID updatedBy;
+	private LocalDateTime deletedAt;
+	private UUID deletedBy;
+
+	public static AdminUserSanctionResponseDto from(AdminUserSanction sanction) {
+		AdminUserSanctionResponseDto dto = new AdminUserSanctionResponseDto();
+		dto.sanctionId = sanction.getSanctionId();
+		dto.userId = sanction.getUserId();
+		dto.reason = sanction.getReason();
+		dto.sanctionStatus = sanction.getSanctionStatus().getDisplayName();
+		dto.note = sanction.getNote();
+		dto.startDate = sanction.getStartDate();
+		dto.endDate = sanction.getEndDate();
+		dto.createdAt = sanction.getCreatedAt();
+		dto.createdBy = sanction.getCreatedBy();
+		dto.updatedAt = sanction.getUpdatedAt();
+		dto.updatedBy = sanction.getUpdatedBy();
+		dto.deletedAt = sanction.getDeletedAt();
+		dto.deletedBy = sanction.getDeletedBy();
+		return dto;
+	}
+}

--- a/src/main/java/com/example/demo/admin/entity/AdminReport.java
+++ b/src/main/java/com/example/demo/admin/entity/AdminReport.java
@@ -45,7 +45,7 @@ public class AdminReport {
 	private UserEntity reported;
 
 	@Column(name = "report_type", nullable = false)
-	private String reportType; // USER / STORE / REVIEW
+	private String reportType; // CUSTOMER / STORE / REVIEW
 
 	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
 	private String content;

--- a/src/main/java/com/example/demo/admin/entity/AdminReport.java
+++ b/src/main/java/com/example/demo/admin/entity/AdminReport.java
@@ -1,0 +1,74 @@
+package com.example.demo.admin.entity;
+
+import java.util.UUID;
+
+import java.time.LocalDateTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import com.example.demo.user.entity.UserEntity;
+
+@Entity
+@Data
+@Table(name = "p_admin_reports")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminReport {
+
+	@Id
+	@GeneratedValue
+	@Column(name = "report_id")
+	private UUID reportId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "reporter_id", nullable = false)
+	private UserEntity reporter; // 신고자 (유저 or 점주), p_user_info 참조
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "reported_id")
+	private UserEntity reported;
+
+	@Column(name = "report_type", nullable = false)
+	private String reportType; // USER / STORE / REVIEW
+
+	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false)
+	private ReportStatus status;
+
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt = LocalDateTime.now();
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Column(name = "created_by", nullable = false)
+	private UUID createdBy;
+
+	@Column(name = "updated_by")
+	private UUID updatedBy;
+
+	@Column(name = "deleted_by")
+	private UUID deletedBy;
+}

--- a/src/main/java/com/example/demo/admin/entity/AdminUserSanction.java
+++ b/src/main/java/com/example/demo/admin/entity/AdminUserSanction.java
@@ -1,0 +1,79 @@
+package com.example.demo.admin.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Table(name = "p_admin_user_sanctions")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class AdminUserSanction {
+
+	@Id
+	@GeneratedValue
+	@Column(name = "sanction_id")
+	private UUID sanctionId;
+
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
+
+	@Column(name = "reason", nullable = false, columnDefinition = "TEXT")
+	private String reason;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "sanction_status", nullable = false)
+	private SanctionStatus sanctionStatus;
+
+	@Column(name = "note", columnDefinition = "TEXT")
+	private String note;
+
+	@Column(name = "start_date", nullable = false)
+	private LocalDateTime startDate;
+
+	@Column(name = "end_date")
+	private LocalDateTime endDate;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt = LocalDateTime.now();
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Column(name = "created_by", nullable = false)
+	private UUID createdBy;
+
+	@Column(name = "updated_by")
+	private UUID updatedBy;
+
+	@Column(name = "deleted_by")
+	private UUID deletedBy;
+
+	public void softDelete(UUID adminId) {
+		this.deletedAt = LocalDateTime.now();
+		this.deletedBy = adminId;
+	}
+}

--- a/src/main/java/com/example/demo/admin/entity/ReportStatus.java
+++ b/src/main/java/com/example/demo/admin/entity/ReportStatus.java
@@ -1,0 +1,20 @@
+package com.example.demo.admin.entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ReportStatus {
+	PENDING("처리 대기"),
+	DONE("처리 완료"),
+	REJECTED("거절됨");
+
+	private final String description;
+
+	ReportStatus(String description) {
+		this.description = description;
+	}
+
+	@JsonValue
+	public String getDescription() {
+		return description;
+	}
+}

--- a/src/main/java/com/example/demo/admin/entity/SanctionStatus.java
+++ b/src/main/java/com/example/demo/admin/entity/SanctionStatus.java
@@ -1,0 +1,16 @@
+package com.example.demo.admin.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum SanctionStatus {
+	WARNING("경고"),
+	SUSPEND("일시 정지"),
+	BAN("영구 정지");
+
+	private final String displayName;
+
+	SanctionStatus(String displayName) {
+		this.displayName = displayName;
+	}
+}

--- a/src/main/java/com/example/demo/admin/exception/ReportAlreadyDeletedException.java
+++ b/src/main/java/com/example/demo/admin/exception/ReportAlreadyDeletedException.java
@@ -1,0 +1,7 @@
+package com.example.demo.admin.exception;
+
+public class ReportAlreadyDeletedException extends RuntimeException {
+	public ReportAlreadyDeletedException() {
+		super("이미 삭제된 신고입니다.");
+	}
+}

--- a/src/main/java/com/example/demo/admin/exception/ReportNotFoundException.java
+++ b/src/main/java/com/example/demo/admin/exception/ReportNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.demo.admin.exception;
+
+public class ReportNotFoundException extends RuntimeException {
+	public ReportNotFoundException() {
+		super("신고 내역이 존재하지 않습니다.");
+	}
+}

--- a/src/main/java/com/example/demo/admin/exception/SanctionNotFoundException.java
+++ b/src/main/java/com/example/demo/admin/exception/SanctionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.demo.admin.exception;
+
+public class SanctionNotFoundException extends RuntimeException {
+	public SanctionNotFoundException() {
+		super("해당 제재가 존재하지 않습니다.");
+	}
+}

--- a/src/main/java/com/example/demo/admin/exception/UnauthorizedReportAccessException.java
+++ b/src/main/java/com/example/demo/admin/exception/UnauthorizedReportAccessException.java
@@ -1,0 +1,7 @@
+package com.example.demo.admin.exception;
+
+public class UnauthorizedReportAccessException extends RuntimeException {
+	public UnauthorizedReportAccessException() {
+		super("관리자만 신고를 삭제할 수 있습니다.");
+	}
+}

--- a/src/main/java/com/example/demo/admin/repository/AdminReportRepository.java
+++ b/src/main/java/com/example/demo/admin/repository/AdminReportRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.admin.repository;
+
+import com.example.demo.admin.entity.AdminReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface AdminReportRepository extends JpaRepository<AdminReport, UUID> {
+}

--- a/src/main/java/com/example/demo/admin/repository/AdminUserSanctionRepository.java
+++ b/src/main/java/com/example/demo/admin/repository/AdminUserSanctionRepository.java
@@ -1,0 +1,14 @@
+package com.example.demo.admin.repository;
+
+import com.example.demo.admin.entity.AdminUserSanction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AdminUserSanctionRepository extends JpaRepository<AdminUserSanction, UUID> {
+
+	// 삭제되지 않은 제재 목록
+	List<AdminUserSanction> findAllByDeletedAtIsNull();
+
+}

--- a/src/main/java/com/example/demo/admin/service/AdminReportService.java
+++ b/src/main/java/com/example/demo/admin/service/AdminReportService.java
@@ -4,13 +4,15 @@ import com.example.demo.admin.dto.AdminReportRequestDto;
 import com.example.demo.admin.dto.AdminReportResponseDto;
 import com.example.demo.admin.entity.AdminReport;
 import com.example.demo.admin.entity.ReportStatus;
+import com.example.demo.admin.exception.ReportAlreadyDeletedException;
+import com.example.demo.admin.exception.ReportNotFoundException;
+import com.example.demo.admin.exception.UnauthorizedReportAccessException;
 import com.example.demo.admin.repository.AdminReportRepository;
 import com.example.demo.user.entity.UserEntity;
 import com.example.demo.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -25,8 +27,8 @@ public class AdminReportService {
 
 	public AdminReportResponseDto createReport(AdminReportRequestDto dto, UUID reporterId) {
 		AdminReport report = AdminReport.builder()
-			.reporter(UserEntity.builder().userId(reporterId).build()) // Lazy 참조용 껍데기
-			.reported(UserEntity.builder().userId(dto.getReportedId()).build()) // 이 부분도 실제 엔티티로 참조
+			.reporter(UserEntity.builder().userId(reporterId).build())
+			.reported(UserEntity.builder().userId(dto.getReportedId()).build())
 			.reportType(dto.getReportType())
 			.content(dto.getContent())
 			.status(ReportStatus.PENDING)
@@ -40,7 +42,7 @@ public class AdminReportService {
 
 	public AdminReportResponseDto updateReportStatus(UUID reportId, ReportStatus newStatus, UUID adminId) {
 		AdminReport report = adminReportRepository.findById(reportId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 신고 내역이 없습니다."));
+			.orElseThrow(ReportNotFoundException::new);
 
 		report.setStatus(newStatus);
 		report.setUpdatedBy(adminId);
@@ -52,22 +54,23 @@ public class AdminReportService {
 
 	public AdminReportResponseDto getReportById(UUID reportId) {
 		AdminReport report = adminReportRepository.findById(reportId)
-			.orElseThrow(() -> new IllegalArgumentException("신고 내역이 존재하지 않습니다."));
+			.orElseThrow(ReportNotFoundException::new);
 		return AdminReportResponseDto.fromEntity(report);
 	}
+
 	public void deleteReport(UUID reportId, UUID userId) {
 		UserEntity user = userRepository.findById(userId)
-			.orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+			.orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다.")); // 이건 사용자 공통 예외로 남겨도 괜찮습니다
 
 		if (user.getRole() != UserEntity.UserRole.ADMIN) {
-			throw new AccessDeniedException("관리자만 신고를 삭제할 수 있습니다.");
+			throw new UnauthorizedReportAccessException();
 		}
 
 		AdminReport report = adminReportRepository.findById(reportId)
-			.orElseThrow(() -> new IllegalArgumentException("신고 내역이 존재하지 않습니다."));
+			.orElseThrow(ReportNotFoundException::new);
 
 		if (report.getDeletedAt() != null) {
-			throw new IllegalStateException("이미 삭제된 신고입니다.");
+			throw new ReportAlreadyDeletedException();
 		}
 
 		report.setDeletedAt(LocalDateTime.now());

--- a/src/main/java/com/example/demo/admin/service/AdminReportService.java
+++ b/src/main/java/com/example/demo/admin/service/AdminReportService.java
@@ -1,0 +1,78 @@
+package com.example.demo.admin.service;
+
+import com.example.demo.admin.dto.AdminReportRequestDto;
+import com.example.demo.admin.dto.AdminReportResponseDto;
+import com.example.demo.admin.entity.AdminReport;
+import com.example.demo.admin.entity.ReportStatus;
+import com.example.demo.admin.repository.AdminReportRepository;
+import com.example.demo.user.entity.UserEntity;
+import com.example.demo.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AdminReportService {
+
+	private final AdminReportRepository adminReportRepository;
+	private final UserRepository userRepository;
+
+	public AdminReportResponseDto createReport(AdminReportRequestDto dto, UUID reporterId) {
+		AdminReport report = AdminReport.builder()
+			.reporter(UserEntity.builder().userId(reporterId).build()) // Lazy 참조용 껍데기
+			.reported(UserEntity.builder().userId(dto.getReportedId()).build()) // 이 부분도 실제 엔티티로 참조
+			.reportType(dto.getReportType())
+			.content(dto.getContent())
+			.status(ReportStatus.PENDING)
+			.createdAt(LocalDateTime.now())
+			.createdBy(reporterId)
+			.build();
+
+		AdminReport saved = adminReportRepository.save(report);
+		return AdminReportResponseDto.fromEntity(saved);
+	}
+
+	public AdminReportResponseDto updateReportStatus(UUID reportId, ReportStatus newStatus, UUID adminId) {
+		AdminReport report = adminReportRepository.findById(reportId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 신고 내역이 없습니다."));
+
+		report.setStatus(newStatus);
+		report.setUpdatedBy(adminId);
+		report.setUpdatedAt(LocalDateTime.now());
+
+		AdminReport updated = adminReportRepository.save(report);
+		return AdminReportResponseDto.fromEntity(updated);
+	}
+
+	public AdminReportResponseDto getReportById(UUID reportId) {
+		AdminReport report = adminReportRepository.findById(reportId)
+			.orElseThrow(() -> new IllegalArgumentException("신고 내역이 존재하지 않습니다."));
+		return AdminReportResponseDto.fromEntity(report);
+	}
+	public void deleteReport(UUID reportId, UUID userId) {
+		UserEntity user = userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+
+		if (user.getRole() != UserEntity.UserRole.ADMIN) {
+			throw new AccessDeniedException("관리자만 신고를 삭제할 수 있습니다.");
+		}
+
+		AdminReport report = adminReportRepository.findById(reportId)
+			.orElseThrow(() -> new IllegalArgumentException("신고 내역이 존재하지 않습니다."));
+
+		if (report.getDeletedAt() != null) {
+			throw new IllegalStateException("이미 삭제된 신고입니다.");
+		}
+
+		report.setDeletedAt(LocalDateTime.now());
+		report.setDeletedBy(userId);
+
+		adminReportRepository.save(report);
+	}
+}

--- a/src/main/java/com/example/demo/admin/service/AdminUserSanctionService.java
+++ b/src/main/java/com/example/demo/admin/service/AdminUserSanctionService.java
@@ -1,0 +1,58 @@
+package com.example.demo.admin.service;
+
+import com.example.demo.admin.dto.AdminUserSanctionRequestDto;
+import com.example.demo.admin.dto.AdminUserSanctionResponseDto;
+import com.example.demo.admin.entity.AdminUserSanction;
+import com.example.demo.admin.exception.SanctionNotFoundException;
+import com.example.demo.admin.repository.AdminUserSanctionRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserSanctionService {
+
+	private final AdminUserSanctionRepository repository;
+
+	public List<AdminUserSanctionResponseDto> getAllSanctions() {
+		return repository.findAllByDeletedAtIsNull()
+			.stream()
+			.map(AdminUserSanctionResponseDto::from)
+			.toList();
+	}
+
+	public AdminUserSanctionResponseDto createSanction(AdminUserSanctionRequestDto dto, UUID adminId) {
+		LocalDateTime startDate = dto.getStartDate();
+
+		LocalDateTime endDate = switch (dto.getSanctionStatus()) {
+			case WARNING, BAN -> null;
+			case SUSPEND -> dto.getEndDate();
+		};
+
+		AdminUserSanction sanction = AdminUserSanction.builder()
+			.sanctionId(null)
+			.userId(dto.getUserId())
+			.reason(dto.getReason())
+			.sanctionStatus(dto.getSanctionStatus())
+			.note(dto.getNote())
+			.startDate(startDate)
+			.endDate(endDate)
+			.createdBy(adminId)
+			.build();
+
+		return AdminUserSanctionResponseDto.from(repository.save(sanction));
+	}
+
+	public void deleteSanction(UUID sanctionId, UUID deletedBy) {
+		AdminUserSanction sanction = repository.findById(sanctionId)
+			.orElseThrow(SanctionNotFoundException::new);
+
+		sanction.softDelete(deletedBy);
+		repository.save(sanction);
+	}
+}

--- a/src/main/java/com/example/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/SecurityConfig.java
@@ -40,20 +40,23 @@ public class SecurityConfig {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
-            // .exceptionHandling(exceptionHandling -> exceptionHandling
-            //     .accessDeniedHandler(jwtAccessDeniedHandler)
-            //     .authenticationEntryPoint(jwtAuthenticationEntryPoint)
-            // )
+            .exceptionHandling(exceptionHandling -> exceptionHandling
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+            )
             .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
-                .requestMatchers("/api/user/signup", "/api/user/login",
-                    "/api/user/refresh", "/api/user/logout", 
-                    "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                .requestMatchers(
+                    "/api/user/signup", "/api/user/login",
+                    "/api/user/refresh", "/api/user/logout",
+                    "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html"
+                ).permitAll()
                 .anyRequest().authenticated()
             )
             .sessionManagement(sessionManagement ->
                 sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
-            .with(new JwtSecurityConfig(accessTokenProvider), customizer -> {});
+            .with(new JwtSecurityConfig(accessTokenProvider), customizer -> {
+            });
         return http.build();
     }
 }

--- a/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
@@ -15,4 +15,11 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.BAD_REQUEST) // 400
                 .body(ex.getMessage());
     }
+    // IllegalStateException → 409 Conflict
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<String> handleIllegalStateException(IllegalStateException ex) {
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)  // 409
+            .body(ex.getMessage());
+    }
 }

--- a/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import com.example.demo.admin.exception.ReportAlreadyDeletedException;
+import com.example.demo.admin.exception.ReportNotFoundException;
+import com.example.demo.admin.exception.SanctionNotFoundException;
+import com.example.demo.admin.exception.UnauthorizedReportAccessException;
+
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -21,5 +26,23 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.CONFLICT)  // 409
             .body(ex.getMessage());
+    }
+    @ExceptionHandler(ReportNotFoundException.class)
+    public ResponseEntity<String> handleReportNotFound(ReportNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(ReportAlreadyDeletedException.class)
+    public ResponseEntity<String> handleReportAlreadyDeleted(ReportAlreadyDeletedException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(UnauthorizedReportAccessException.class)
+    public ResponseEntity<String> handleUnauthorizedReportAccess(UnauthorizedReportAccessException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
+    }
+    @ExceptionHandler(SanctionNotFoundException.class)
+    public ResponseEntity<String> handleSanctionNotFound(SanctionNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
 }

--- a/src/main/java/com/example/demo/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/demo/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.example.demo.global.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException {
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
+		response.setContentType("application/json;charset=UTF-8");
+		response.getWriter().write("{\"message\": \"관리자만 신고를 삭제할 수 있습니다.\"}");
+	}
+}

--- a/src/main/java/com/example/demo/user/entity/UserEntity.java
+++ b/src/main/java/com/example/demo/user/entity/UserEntity.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class UserEntity {
 
 	@Id

--- a/src/test/java/com/example/demo/admin/AdminReportServiceTest.java
+++ b/src/test/java/com/example/demo/admin/AdminReportServiceTest.java
@@ -1,0 +1,150 @@
+package com.example.demo.admin;
+
+import com.example.demo.admin.dto.AdminReportRequestDto;
+import com.example.demo.admin.dto.AdminReportResponseDto;
+import com.example.demo.admin.entity.AdminReport;
+import com.example.demo.admin.entity.ReportStatus;
+import com.example.demo.admin.repository.AdminReportRepository;
+import com.example.demo.admin.service.AdminReportService;
+import com.example.demo.user.entity.UserEntity;
+import com.example.demo.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AdminReportServiceTest {
+
+	@Mock
+	private AdminReportRepository adminReportRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private AdminReportService adminReportService;
+
+	@Test
+	void createReport_정상생성() {
+		// given
+		UUID reporterId = UUID.randomUUID();
+		UUID reportedId = UUID.randomUUID();
+
+		AdminReportRequestDto dto = AdminReportRequestDto.builder()
+			.reportedId(reportedId)
+			.reportType("USER")
+			.content("불법적인 활동")
+			.build();
+
+		when(adminReportRepository.save(any())).thenAnswer(invocation -> {
+			AdminReport report = invocation.getArgument(0);
+			report.setReportId(UUID.randomUUID());
+			return report;
+		});
+
+		// when
+		AdminReportResponseDto response = adminReportService.createReport(dto, reporterId);
+
+		// then
+		ArgumentCaptor<AdminReport> captor = ArgumentCaptor.forClass(AdminReport.class);
+		verify(adminReportRepository).save(captor.capture());
+
+		AdminReport saved = captor.getValue();
+		assertThat(saved.getReporter().getUserId()).isEqualTo(reporterId);
+		assertThat(saved.getReported().getUserId()).isEqualTo(reportedId);
+		assertThat(saved.getReportType()).isEqualTo("USER");
+		assertThat(saved.getContent()).isEqualTo("불법적인 활동");
+		assertThat(saved.getStatus()).isEqualTo(ReportStatus.PENDING);
+
+		System.out.println("🧪 신고 생성 테스트 결과\n신고자: " + response.getReporter().getUserId() +
+			"\n피신고자: " + response.getReported().getUserId() +
+			"\n유형: " + response.getReportType() +
+			"\n내용: " + response.getContent());
+	}
+
+	@Test
+	void deleteReport_관리자가_삭제요청하면_정상작동() {
+		// given
+		UUID reportId = UUID.randomUUID();
+		UUID adminId = UUID.randomUUID();
+
+		UserEntity admin = UserEntity.builder()
+			.userId(adminId)
+			.name("관리자")
+			.birthdate(LocalDate.of(1990, 1, 1))
+			.phone("01012345678")
+			.email("admin@example.com")
+			.loginId("admin")
+			.password("pw")
+			.nickname("관리자")
+			.createdBy(adminId)
+			.role(UserEntity.UserRole.ADMIN)
+			.build();
+
+		AdminReport report = AdminReport.builder()
+			.reportId(reportId)
+			.reporter(admin)
+			.reported(admin)
+			.reportType("USER")
+			.content("스팸")
+			.status(ReportStatus.PENDING)
+			.createdBy(adminId)
+			.createdAt(LocalDateTime.now())
+			.build();
+
+		when(userRepository.findById(adminId)).thenReturn(Optional.of(admin));
+		when(adminReportRepository.findById(reportId)).thenReturn(Optional.of(report));
+
+		// when
+		adminReportService.deleteReport(reportId, adminId);
+
+		// then
+		assertThat(report.getDeletedAt()).isNotNull();
+		assertThat(report.getDeletedBy()).isEqualTo(adminId);
+
+		System.out.println("🧪 신고 삭제 테스트 결과\n삭제 시간: " + report.getDeletedAt() +
+			"\n삭제자 ID: " + report.getDeletedBy());
+	}
+
+	@Test
+	void deleteReport_관리자아닌경우_예외발생() {
+		// given
+		UUID reportId = UUID.randomUUID();
+		UUID nonAdminId = UUID.randomUUID();
+
+		UserEntity nonAdmin = UserEntity.builder()
+			.userId(nonAdminId)
+			.name("유저")
+			.birthdate(LocalDate.of(1995, 5, 5))
+			.phone("01011112222")
+			.email("user@example.com")
+			.loginId("user")
+			.password("pw")
+			.nickname("유저")
+			.createdBy(nonAdminId)
+			.role(UserEntity.UserRole.CUSTOMER)
+			.build();
+
+		when(userRepository.findById(nonAdminId)).thenReturn(Optional.of(nonAdmin));
+
+		// when & then
+		assertThrows(AccessDeniedException.class, () -> {
+			adminReportService.deleteReport(reportId, nonAdminId);
+		});
+
+		System.out.println("❌ 관리자 권한 없는 유저가 삭제 요청 시 예외 발생 확인 완료");
+	}
+}

--- a/src/test/java/com/example/demo/admin/AdminUserSanctionServiceTest.java
+++ b/src/test/java/com/example/demo/admin/AdminUserSanctionServiceTest.java
@@ -1,0 +1,83 @@
+package com.example.demo.admin;
+
+import com.example.demo.admin.dto.AdminUserSanctionRequestDto;
+import com.example.demo.admin.dto.AdminUserSanctionResponseDto;
+import com.example.demo.admin.entity.AdminUserSanction;
+import com.example.demo.admin.entity.SanctionStatus;
+import com.example.demo.admin.repository.AdminUserSanctionRepository;
+import com.example.demo.admin.service.AdminUserSanctionService;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AdminUserSanctionServiceTest {
+
+	@Mock
+	private AdminUserSanctionRepository repository;
+
+	@InjectMocks
+	private AdminUserSanctionService service;
+
+	@Test
+	void createSanction_정상생성() {
+		// given
+		UUID userId = UUID.randomUUID();
+		UUID adminId = UUID.randomUUID();
+		UUID sanctionId = UUID.randomUUID();
+
+		AdminUserSanctionRequestDto requestDto = AdminUserSanctionRequestDto.builder()
+			.userId(userId)
+			.reason("테스트 사유")
+			.sanctionStatus(SanctionStatus.SUSPEND)
+			.note("테스트 비고")
+			.startDate(LocalDateTime.of(2025, 8, 1, 0, 0))
+			.endDate(LocalDateTime.of(2025, 8, 7, 0, 0))
+			.build();
+
+		when(repository.save(any())).thenAnswer(invocation -> {
+			AdminUserSanction sanction = invocation.getArgument(0);
+			sanction.setSanctionId(sanctionId);
+			return sanction;
+		});
+
+		// when
+		AdminUserSanctionResponseDto response = service.createSanction(requestDto, adminId);
+
+		// then
+		ArgumentCaptor<AdminUserSanction> captor = ArgumentCaptor.forClass(AdminUserSanction.class);
+		verify(repository).save(captor.capture());
+		AdminUserSanction saved = captor.getValue();
+
+		// assertions
+		assertThat(saved.getUserId()).isEqualTo(userId);
+		assertThat(saved.getCreatedBy()).isEqualTo(adminId);
+		assertThat(saved.getSanctionStatus()).isEqualTo(SanctionStatus.SUSPEND);
+		assertThat(saved.getStartDate()).isEqualTo(requestDto.getStartDate());
+		assertThat(saved.getEndDate()).isEqualTo(requestDto.getEndDate());
+
+		assertThat(response.getUserId()).isEqualTo(userId);
+		assertThat(response.getSanctionId()).isEqualTo(sanctionId);
+
+		// 🧪 로그 출력
+		System.out.println("🧪 제재 생성 테스트 결과");
+		System.out.println("유저 ID: " + response.getUserId());
+		System.out.println("제재 ID: " + response.getSanctionId());
+		System.out.println("제재 상태: " + response.getSanctionStatus());
+		System.out.println("시작일: " + response.getStartDate());
+		System.out.println("종료일: " + response.getEndDate());
+		System.out.println("비고: " + response.getNote());
+	}
+}

--- a/src/test/java/com/example/demo/store/StoreServiceTest.java
+++ b/src/test/java/com/example/demo/store/StoreServiceTest.java
@@ -14,6 +14,7 @@ import com.example.demo.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDate;
 import java.util.Optional;

--- a/src/test/java/com/example/demo/store/StoreServiceTest.java
+++ b/src/test/java/com/example/demo/store/StoreServiceTest.java
@@ -36,7 +36,6 @@ public class StoreServiceTest {
 
 	@Test
 	void 가게등록_및_수정테스트() {
-		// 테스트용 사용자 생성 및 저장
 		UserEntity testUser = UserEntity.builder()
 			.name("테스트유저")
 			.birthdate(LocalDate.of(1995, 1, 1))
@@ -50,7 +49,6 @@ public class StoreServiceTest {
 			.build();
 		testUser = userRepository.save(testUser);
 
-		// 가게 등록용 DTO
 		StoreCreateRequestDto createDto = new StoreCreateRequestDto();
 		createDto.setName("테스트치킨");
 		createDto.setBusinessNum("1234567890");
@@ -64,14 +62,16 @@ public class StoreServiceTest {
 		createDto.setIntroduction("테스트 가게 소개");
 		createDto.setIsAvailable(StoreStatus.OPEN);
 
-		// 가게 등록
 		StoreResponseDto saved = storeService.createStore(createDto, testUser.getUserId().toString());
 		UUID storeId = saved.getStoreId();
 
 		assertThat(saved.getName()).isEqualTo("테스트치킨");
 		assertThat(saved.getAiDescription()).isNotBlank();
 
-		// 수정용 DTO
+		System.out.println("🧪 가게 등록 테스트 결과");
+		System.out.printf(" - 이름: %s%n", saved.getName());
+		System.out.printf(" - AI 소개글: %s%n%n", saved.getAiDescription());
+
 		StoreUpdateRequestDto updateDto = new StoreUpdateRequestDto();
 		updateDto.setName("수정된치킨");
 		updateDto.setCategory(Category.KOREAN);
@@ -84,10 +84,8 @@ public class StoreServiceTest {
 		updateDto.setIntroduction("수정된 가게 소개");
 		updateDto.setIsAvailable(StoreStatus.CLOSED);
 
-		// 가게 수정
 		storeService.updateStore(storeId, updateDto);
 
-		// 검증
 		Optional<StoreEntity> updatedOpt = storeRepository.findById(storeId);
 		assertThat(updatedOpt).isPresent();
 		StoreEntity updated = updatedOpt.get();
@@ -96,5 +94,11 @@ public class StoreServiceTest {
 		assertThat(updated.getPhoneNum()).isEqualTo("01098765432");
 		assertThat(updated.getIntroduction()).isEqualTo("수정된 가게 소개");
 		assertThat(updated.getAiDescription()).isNotBlank();
+
+		System.out.println("🧪 가게 수정 테스트 결과");
+		System.out.printf(" - 수정 이름: %s%n", updated.getName());
+		System.out.printf(" - 전화번호: %s%n", updated.getPhoneNum());
+		System.out.printf(" - 소개글: %s%n", updated.getIntroduction());
+		System.out.printf(" - AI 소개글: %s%n%n", updated.getAiDescription());
 	}
 }


### PR DESCRIPTION
## 🔍 개요
- 관리자 신고/제재 기능 구현
- 커스텀 예외 분리
- 서비스 단위 테스트 추가

## ✅ 작업 내용
- [x] 주요 기능 개발
- [ ] 버그 수정
- [x] 코드 리팩토링
- [x] 테스트 코드 추가

## 📌 변경 사항
- AdminReportService / AdminUserSanctionService 기능 구현
  - 신고 생성, 조회, 상태 변경, 삭제 로직 작성
  - 유저 제재 생성, 조회, 삭제 로직 작성

- 도메인별 커스텀 예외 분리
  - ReportNotFoundException, ReportAlreadyDeletedException, UnauthorizedReportAccessException 등 생성
  - SanctionNotFoundException 생성 및 적용

- GlobalExceptionHandler에도 커스텀 예외 매핑 추가

- 각 서비스 단위 테스트 코드 추가
- 정상 동작 및 예외 발생 케이스 검증 ?

## 🚨 주의 사항
- StoreEntityTest는 Mok X
- StoreServiceTest는 AI 코드 수정된 거 확인 후 테스트 코드 Mok 으로 수정 예정입니다.

## 📎 관련 이슈
- 관련된 이슈 번호 또는 링크: `#이슈번호`
