### PR TITLE
Feat: 공통 검색기능 및 검색페이지 조회 구현

### DIFF
--- a/src/main/java/com/example/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
 					"/swagger-ui/**", "/swagger-ui.html",
 					"/v3/api-docs/**", "/swagger-resources/**",
 					"/swagger-resources", "/configuration/**",
-					"/webjars/**"
+					"/webjars/**","/api/search/**",   // 🔍 검색 관련 URI는 모두 허용
+					"/api/public/**"
                 ).permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.example.demo.global.exception;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -9,6 +12,7 @@ import com.example.demo.admin.exception.ReportAlreadyDeletedException;
 import com.example.demo.admin.exception.ReportNotFoundException;
 import com.example.demo.admin.exception.SanctionNotFoundException;
 import com.example.demo.admin.exception.UnauthorizedReportAccessException;
+import com.example.demo.search.exception.SearchException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -44,5 +48,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(SanctionNotFoundException.class)
     public ResponseEntity<String> handleSanctionNotFound(SanctionNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+    @ExceptionHandler(SearchException.class)
+    public ResponseEntity<Map<String, String>> handleSearchException(SearchException e) {
+        Map<String, String> body = new HashMap<>();
+        body.put("error", e.getMessage());
+        return ResponseEntity.badRequest().body(body);
     }
 }

--- a/src/main/java/com/example/demo/search/controller/SearchController.java
+++ b/src/main/java/com/example/demo/search/controller/SearchController.java
@@ -1,0 +1,29 @@
+package com.example.demo.search.controller;
+
+import com.example.demo.search.dto.SearchResultDto;
+import com.example.demo.search.exception.SearchException;
+import com.example.demo.search.service.SearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+	private final SearchService searchService;
+
+	@GetMapping
+	public Page<SearchResultDto> search(
+		@RequestParam String keyword,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size,
+		@RequestParam(defaultValue = "created") String sortBy
+	) {
+		if (keyword == null || keyword.isBlank()) {
+			throw new SearchException();
+		}
+		return searchService.search(keyword, page, size, sortBy);
+	}
+}

--- a/src/main/java/com/example/demo/search/dto/SearchResultDto.java
+++ b/src/main/java/com/example/demo/search/dto/SearchResultDto.java
@@ -1,0 +1,28 @@
+package com.example.demo.search.dto;
+
+import com.example.demo.store.entity.StoreEntity;
+import com.example.demo.store.entity.Category;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchResultDto {
+	private UUID storeId;
+	private String storeName;
+	private String category;
+	private String imgURL;
+
+	public static SearchResultDto fromEntity(StoreEntity store) {
+		return new SearchResultDto(
+			store.getStoreId(),
+			store.getName(),
+			store.getCategory().getDescription(),
+			store.getImgURL()
+		);
+	}
+}

--- a/src/main/java/com/example/demo/search/exception/SearchException.java
+++ b/src/main/java/com/example/demo/search/exception/SearchException.java
@@ -1,0 +1,8 @@
+package com.example.demo.search.exception;
+
+public class SearchException extends RuntimeException {
+
+	public SearchException() {
+		super("검색어를 입력해주세요.");
+	}
+}

--- a/src/main/java/com/example/demo/search/service/SearchService.java
+++ b/src/main/java/com/example/demo/search/service/SearchService.java
@@ -1,0 +1,36 @@
+package com.example.demo.search.service;
+
+import com.example.demo.search.dto.SearchResultDto;
+import com.example.demo.store.entity.StoreEntity;
+import com.example.demo.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+	private final StoreRepository storeRepository;
+
+	public Page<SearchResultDto> search(String keyword, int page, int size, String sortBy) {
+		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, convertSortKey(sortBy)));
+
+		Page<StoreEntity> storePage = storeRepository.searchVisibleStoresByKeyword(keyword, pageable);
+
+		List<SearchResultDto> resultDtoList = storePage.stream()
+			.map(SearchResultDto::fromEntity)
+			.toList();
+
+		return new PageImpl<>(resultDtoList, pageable, storePage.getTotalElements());
+	}
+
+	private String convertSortKey(String sortBy) {
+		return switch (sortBy.toLowerCase()) {
+			case "name" -> "name";
+			case "created" -> "createdAt";
+			default -> "createdAt"; // 기본값
+		};
+	}
+}

--- a/src/main/java/com/example/demo/store/entity/Category.java
+++ b/src/main/java/com/example/demo/store/entity/Category.java
@@ -16,4 +16,7 @@ public enum Category {
 		this.description = description;
 	}
 
+	public String getDescription() {
+		return description;
+	}
 }

--- a/src/main/java/com/example/demo/store/entity/StoreEntity.java
+++ b/src/main/java/com/example/demo/store/entity/StoreEntity.java
@@ -3,11 +3,14 @@ package com.example.demo.store.entity;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import com.example.demo.menus.entity.MenuEntity;
 import com.example.demo.store.dto.StoreCreateRequestDto;
 import com.example.demo.store.dto.StoreUpdateRequestDto;
 import com.example.demo.user.entity.UserEntity;
@@ -22,6 +25,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -57,6 +61,9 @@ public class StoreEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(name = "category", nullable = false)
 	private Category category;
+
+	@OneToMany(mappedBy = "store", fetch = FetchType.LAZY)
+	private List<MenuEntity> menus = new ArrayList<>();
 
 	@Column(name = "address1", nullable = false, length = 255)
 	private String address1;

--- a/src/main/java/com/example/demo/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/demo/store/repository/StoreRepository.java
@@ -1,18 +1,32 @@
 package com.example.demo.store.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.demo.store.entity.StoreEntity;
 
 @Repository
 public interface StoreRepository extends JpaRepository<StoreEntity, UUID> {
+
 	boolean existsByNameIgnoreCaseAndAddress1IgnoreCaseAndAddress2IgnoreCaseAndDeletedAtIsNull(
 		String name, String address1, String address2
 	);
+
+	@Query("SELECT DISTINCT s FROM StoreEntity s " +
+		"LEFT JOIN s.menus m " +
+		"WHERE s.deletedAt IS NULL AND s.isAvailable <> com.example.demo.store.entity.StoreStatus.DELETED " +
+		"AND (LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+		"OR LOWER(s.category) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+		"OR LOWER(m.name) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+	Page<StoreEntity> searchVisibleStoresByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
 	/**
 	 * storeId가 userId(사장)의 가게로 등록되어 있는지 여부

--- a/src/main/java/com/example/demo/store/service/StoreService.java
+++ b/src/main/java/com/example/demo/store/service/StoreService.java
@@ -1,8 +1,10 @@
 package com.example.demo.store.service;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.example.demo.search.dto.SearchResultDto;
 import com.example.demo.store.dto.StoreCreateRequestDto;
 import com.example.demo.store.dto.StoreResponseDto;
 import com.example.demo.store.dto.StoreUpdateRequestDto;
@@ -14,6 +16,11 @@ import com.example.demo.user.repository.UserRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -23,6 +30,22 @@ public class StoreService {
 	private final StoreRepository storeRepository;
 	private final StoreAiService storeAiService;
 	private final UserRepository userRepository;
+
+	public Page<SearchResultDto> search(String keyword, int page, int size, String sortBy) {
+		Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+		if ("modified".equalsIgnoreCase(sortBy)) {
+			sort = Sort.by(Sort.Direction.DESC, "updatedAt");
+		}
+
+		if (size != 10 && size != 30 && size != 50) {
+			size = 10;
+		}
+
+		Pageable pageable = PageRequest.of(page, size, sort);
+		Page<StoreEntity> resultPage = storeRepository.searchVisibleStoresByKeyword(keyword, pageable);
+
+		return resultPage.map(SearchResultDto::fromEntity);
+	}
 
 	public StoreResponseDto createStore(StoreCreateRequestDto dto, String userId) {
 		boolean exists = storeRepository.existsByNameIgnoreCaseAndAddress1IgnoreCaseAndAddress2IgnoreCaseAndDeletedAtIsNull(

--- a/src/test/java/com/example/demo/search/SearchServiceTest.java
+++ b/src/test/java/com/example/demo/search/SearchServiceTest.java
@@ -1,0 +1,98 @@
+package com.example.demo.search;
+
+import com.example.demo.search.dto.SearchResultDto;
+import com.example.demo.search.service.SearchService;
+import com.example.demo.store.entity.Category;
+import com.example.demo.store.entity.StoreEntity;
+import com.example.demo.store.repository.StoreRepository;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class SearchServiceTest {
+
+	@Mock
+	private StoreRepository storeRepository;
+
+	@InjectMocks
+	private SearchService searchService;
+
+	public SearchServiceTest() {
+		MockitoAnnotations.openMocks(this);
+	}
+
+	@Test
+	void 키워드로_가게_검색_정상작동() {
+		// given
+		String keyword = "한솥";
+		int page = 0;
+		int size = 10;
+		String sortBy = "created";
+
+		UUID storeId = UUID.randomUUID();
+		StoreEntity store = StoreEntity.builder()
+			.storeId(storeId)
+			.name("한솥도시락")
+			.category(Category.KOREAN) // 한식
+			.imgURL("http://image.com/abc.jpg")
+			.build();
+
+		Page<StoreEntity> storePage = new PageImpl<>(List.of(store));
+		Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+
+		when(storeRepository.searchVisibleStoresByKeyword(keyword, pageable)).thenReturn(storePage);
+
+		// when
+		Page<SearchResultDto> result = searchService.search(keyword, page, size, sortBy);
+
+		// then
+		assertThat(result.getContent()).hasSize(1);
+		SearchResultDto dto = result.getContent().get(0);
+
+		System.out.println("🔍 검색 결과:");
+		System.out.println("ID: " + dto.getStoreId());
+		System.out.println("이름: " + dto.getStoreName());
+		System.out.println("카테고리: " + dto.getCategory());
+		System.out.println("이미지 URL: " + dto.getImgURL());
+
+		assertThat(dto.getStoreName()).isEqualTo("한솥도시락");
+		assertThat(dto.getCategory()).isEqualTo("한식");
+		assertThat(dto.getImgURL()).isEqualTo("http://image.com/abc.jpg");
+
+		verify(storeRepository, times(1)).searchVisibleStoresByKeyword(keyword, pageable);
+	}
+	@Test
+	void 검색결과_없을때_빈페이지_반환() {
+		// given
+		String keyword = "없는가게";
+		int page = 0;
+		int size = 10;
+		String sortBy = "created";
+
+		Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+		Page<StoreEntity> emptyPage = new PageImpl<>(List.of());  // 빈 결과
+
+		when(storeRepository.searchVisibleStoresByKeyword(keyword, pageable)).thenReturn(emptyPage);
+
+		// when
+		Page<SearchResultDto> result = searchService.search(keyword, page, size, sortBy);
+
+		// then
+		System.out.println("🔍 검색 결과 없음 테스트:");
+		System.out.println("검색 결과 수: " + result.getContent().size());
+
+		assertThat(result.getContent()).isEmpty();
+		assertThat(result.getTotalElements()).isEqualTo(0);
+
+		verify(storeRepository, times(1)).searchVisibleStoresByKeyword(keyword, pageable);
+	}
+}


### PR DESCRIPTION
## 🔍 개요
- 스토어 관련 코드 조금 수정했습니다.

## ✅ 작업 내용
- [x] 주요 기능 개발
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [x] 테스트 코드 추가

## 📌 변경 사항
- 가게 이름, 카테고리, 메뉴 이름 기반 검색 기능 구현
- 검색 결과 페이징 및 정렬 기능 추가 (created, name 등)
- 카테고리 한글명 출력 지원 (Enum -> getDescription 활용)
- 검색어 없을 경우 예외 처리 추가 (SearchException)
- GlobalExceptionHandler에 SearchException 처리 로직 추가
- 검색 서비스 단위 테스트(Mock) 추가

## 🚨 주의 사항
- postman 에 http://localhost:8080/api/search?keyword=&page=0&size=10&sortBy=created 빈값 GET으로 던졌을 시 에러메시지 잘 나오는지 확인
- DB테이블에 등록되어있는 가게 위주 카테고리, 메뉴, 가게 이름 리스트 잘 뽑히는지 확인
- 폐업 요청 , 폐업 가게 리스트는 뽑히는데 (삭제된 가게는 안나옴) 다 숨길건지 의견 필요합니당

## 📎 관련 이슈
- 관련된 이슈 번호 또는 링크: `#이슈번호`
